### PR TITLE
feat: product-designer agent and CLAUDE.md conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,6 @@
+# Conventions
+
+## Git
+
+- **Never commit directly to `main`.** All work happens on a feature branch. `main` is updated only via merged PRs.
+- Feature branches are named `feature/<sprint-name>` (e.g. `feature/mcp-server`).


### PR DESCRIPTION
## Summary

- Adds `product-designer` agent (opus model) that writes plan docs and `prd.json` from brainstorm output
- Adds `CLAUDE.md` with project conventions — most importantly: **never commit to main**
- Reverts the accidental direct commit to main that added the product-designer originally

## Changes

- `.claude/agents/product-designer.md` — opus agent, writes `docs/plans/` and `prd.json`, enforces task design rules to prevent parallel file-write conflicts, encodes the `utcDateExpr` requirement
- `CLAUDE.md` — no-commit-to-main rule, feature branch naming convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)