### PR TITLE
feat(agents): add product-designer agent

### DIFF
--- a/.claude/agents/product-designer.md
+++ b/.claude/agents/product-designer.md
@@ -24,8 +24,8 @@ You do not write code. You do not create GitHub issues. You make sure what gets 
    - Decisions already made and why
    - Tasks broken into units a single agent can complete in one session
    - Acceptance criteria that are specific and verifiable
-4. **Write `prd.json`** matching the schema in `loop/src/lib/prd.ts`:
-   - `sprint`: kebab-case feature name
+4. **Write `docs/prds/<sprint-name>.json`** matching the schema in `loop/src/lib/prd.ts`:
+   - `sprint`: kebab-case feature name (must match the filename)
    - `description`: one sentence
    - `tasks[]`: each with `id`, `title`, `type` (backend/frontend/both), `description`, `acceptanceCriteria[]`
 5. **Task design rules:**

--- a/.claude/agents/product-designer.md
+++ b/.claude/agents/product-designer.md
@@ -1,0 +1,53 @@
+---
+model: opus
+tools: Read,Write,Glob,Grep
+---
+
+# Product Designer
+
+You write clear, practical PRDs and plan documents for the cassini-mcp project. You turn brainstorm outputs and feature decisions into artifacts that builders can act on directly.
+
+## Role
+
+Given a feature description and any decisions already made, produce:
+1. A plan document at `docs/plans/<feature-name>.md`
+2. A `prd.json` at the project root
+
+You do not write code. You do not create GitHub issues. You make sure what gets built is well-understood before anyone starts building.
+
+## Process
+
+1. **Read the feature context.** Check `docs/plans/` for existing plans, read `ORCHESTRATION.md` to understand the pipeline, read `prd.json` if it exists.
+2. **Read the codebase.** Understand what already exists — what files, what patterns, what conventions — so your plan fits the project rather than contradicting it.
+3. **Write the plan document** at `docs/plans/<feature-name>.md` covering:
+   - What the feature is and why it exists (one paragraph, plain language)
+   - Decisions already made and why
+   - Tasks broken into units a single agent can complete in one session
+   - Acceptance criteria that are specific and verifiable
+4. **Write `prd.json`** matching the schema in `loop/src/lib/prd.ts`:
+   - `sprint`: kebab-case feature name
+   - `description`: one sentence
+   - `tasks[]`: each with `id`, `title`, `type` (backend/frontend/both), `description`, `acceptanceCriteria[]`
+5. **Task design rules:**
+   - Each task should touch a coherent set of files — avoid tasks that will race on the same file if run in parallel
+   - If two tasks must edit the same file, make the dependency explicit in the description: "must run after task-00X"
+   - Acceptance criteria must be testable by a script or a `bun test` run — no subjective criteria
+   - 3–5 tasks is the right size for a sprint; more than that, split the sprint
+
+## What good acceptance criteria look like
+
+Bad: "Code is clean and well-structured"
+Good: "get_flybys('Enceladus') returns exactly 23 results"
+
+Bad: "Tests pass"
+Good: "`bun test shared/` exits 0 with at least 3 passing tests"
+
+## Project context
+
+- Runtime: Bun, TypeScript strict mode
+- Database: `cassini.db` (SQLite) at project root
+- MCP server: `mcp/src/index.ts`
+- CLI: `cli/src/index.ts` (not yet built)
+- Shared utilities: `shared/` (not yet built)
+- Test runner: `bun test`
+- All date filtering must use `start_time_utc` via the `utcDateExpr` fragment — never the `date` column (it has 2,349 bad rows including a phantom 29-Feb-14)

--- a/.claude/agents/product-designer.md
+++ b/.claude/agents/product-designer.md
@@ -11,13 +11,13 @@ You write clear, practical PRDs and plan documents for the cassini-mcp project. 
 
 Given a feature description and any decisions already made, produce:
 1. A plan document at `docs/plans/<feature-name>.md`
-2. A `prd.json` at the project root
+2. A `docs/prds/<sprint-name>.json` PRD file
 
 You do not write code. You do not create GitHub issues. You make sure what gets built is well-understood before anyone starts building.
 
 ## Process
 
-1. **Read the feature context.** Check `docs/plans/` for existing plans, read `ORCHESTRATION.md` to understand the pipeline, read `prd.json` if it exists.
+1. **Read the feature context.** Check `docs/plans/` for existing plans, read `ORCHESTRATION.md` to understand the pipeline, check `docs/prds/` for existing PRDs.
 2. **Read the codebase.** Understand what already exists — what files, what patterns, what conventions — so your plan fits the project rather than contradicting it.
 3. **Write the plan document** at `docs/plans/<feature-name>.md` covering:
    - What the feature is and why it exists (one paragraph, plain language)

--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -71,16 +71,17 @@ Each step is either **agentic** (a Claude subprocess does it) or **deterministic
 The `agentloop` CLI (in `loop/`) is the execution engine. Run it from the project root:
 
 ```bash
-cd loop && bun dev         # dev mode
+cd loop && bun dev -- --prd <sprint-name>         # dev mode
 # or
-agentloop                  # compiled binary
-agentloop --resume         # resume a previous run
-agentloop --branch <name>  # specify feature branch
+agentloop --prd <sprint-name>                      # compiled binary
+agentloop --prd <sprint-name> --resume             # resume a previous run
+agentloop --prd <sprint-name> --branch <name>      # specify feature branch
+agentloop --prd <sprint-name> --yes                # skip plan confirmation
 ```
 
 ### What agentloop does
 
-1. Reads the PRD from the project (see `loop/src/lib/prd.ts` for the expected format)
+1. Reads the PRD from `docs/prds/<sprint-name>.json` (see `loop/src/lib/prd.ts` for the expected format)
 2. Calls `claude -p` with no tools to produce a dependency graph and wave order
 3. Presents the execution plan for human approval (with optional feedback loop)
 4. Executes waves in sequence; tasks within a wave run in parallel
@@ -243,6 +244,7 @@ A final **report** is posted as a comment on the epic GitHub issue summarizing:
 | Artifact | Location | Created by |
 |----------|----------|------------|
 | Plan document | `/docs/plans/<feature>.md` | Brainstorming |
+| PRD | `/docs/prds/<sprint>.json` | Brainstorming |
 | Verification scripts | `.claude/verify/<feature>/<task-id>.sh` | Brainstorming |
 | Task→issue mapping | `.claude/task-issues.json` | Brainstorming |
 | Epic issue | GitHub | Brainstorming |

--- a/docs/prds/mcp-server.json
+++ b/docs/prds/mcp-server.json
@@ -1,0 +1,46 @@
+{
+  "sprint": "mcp-server",
+  "description": "A focused MCP server exposing the Cassini mission database as 6 typed tools. Enables natural language questions about flybys, observations, instrument teams, and mission targets via Claude Desktop. This is the MCP half of the cassini-mcp comparison demo.",
+  "createdAt": "2026-03-12",
+  "tasks": [
+    {
+      "id": "task-001",
+      "title": "MCP server scaffolding",
+      "type": "backend",
+      "description": "Create the mcp/ directory with package.json (Bun project, @modelcontextprotocol/sdk dependency), tsconfig.json, and src/index.ts with MCP server initialisation, stdio transport, and a working SQLite database connection to ../cassini.db. Server must start cleanly with bun run dev.",
+      "acceptanceCriteria": [
+        "mcp/package.json exists with @modelcontextprotocol/sdk dependency",
+        "mcp/src/index.ts initialises an MCP server with stdio transport",
+        "Database connection opens ../cassini.db relative to mcp/",
+        "bun run dev from mcp/ starts without error",
+        "Server starts and stays running with no tools registered yet"
+      ]
+    },
+    {
+      "id": "task-002",
+      "title": "Core tools: get_flybys, get_observations, get_body_summary, get_team_stats",
+      "type": "backend",
+      "description": "Implement four tools: get_flybys(target) returning flyby count and dates using request_name = 'ENTAR'; get_observations(target?, team?, date_range?, limit?) returning filtered master_plan rows with full description field, default limit 50; get_body_summary(name) returning planet/moon facts from the planets table; get_team_stats() returning observation count and total duration per instrument team sorted by count descending. All queries must be parameterised.",
+      "acceptanceCriteria": [
+        "get_flybys('Enceladus') returns exactly 23 targeted flyby events",
+        "get_observations({ target: 'Titan' }) returns up to 50 rows with correct fields including full description",
+        "get_body_summary('Enceladus') returns radius_km, mass_kg, discoverer, notes",
+        "get_team_stats() returns all teams sorted by observation count descending",
+        "All tools have precise descriptions suitable for model tool selection",
+        "All queries use parameterised inputs with no string interpolation"
+      ]
+    },
+    {
+      "id": "task-003",
+      "title": "Additional tools: get_mission_timeline, get_targets",
+      "type": "backend",
+      "description": "Implement two more tools by adding to the same mcp/src/index.ts file that task-002 produces. Must run after task-002 is complete. get_mission_timeline(year?) returning observation counts grouped by year, or monthly breakdown when a specific year is provided; get_targets() returning all distinct target names with observation counts sorted by count descending.",
+      "acceptanceCriteria": [
+        "get_mission_timeline() returns one row per year with observation count",
+        "get_mission_timeline(2005) returns monthly breakdown for 2005",
+        "get_targets() returns all distinct targets with counts sorted descending",
+        "Saturn appears at the top of get_targets() results"
+      ]
+    }
+  ]
+}

--- a/docs/prds/readme.json
+++ b/docs/prds/readme.json
@@ -1,0 +1,22 @@
+{
+  "sprint": "readme",
+  "description": "A setup guide for a side-by-side experiment: MCP server vs CLI tool for grounding an AI in the Cassini mission dataset. Opinionated setup, neutral conclusions — the reader draws their own.",
+  "createdAt": "2026-03-12",
+  "tasks": [
+    {
+      "id": "task-001",
+      "title": "Write README.md",
+      "type": "backend",
+      "description": "Write README.md at the project root framing the MCP vs CLI experiment. Cover: what the repo contains, what cassini.db is and why it makes a good test subject, setup instructions for both implementations, 3-5 example questions drawn from actual data (e.g. Enceladus flybys, moon summaries), and a 'how to compare' section. Brief agentloop mention. No declared winner. Link out for MCP internals.",
+      "acceptanceCriteria": [
+        "README.md exists at project root",
+        "Includes MCP vs CLI experiment framing as the hook",
+        "Explains cassini.db dataset (master_plan and planets tables, key fields)",
+        "Setup instructions for both MCP and CLI implementations",
+        "3-5 example questions using actual data from the database",
+        "Includes a how-to-compare section",
+        "File has more than 50 lines"
+      ]
+    }
+  ]
+}

--- a/loop/src/commands/run.ts
+++ b/loop/src/commands/run.ts
@@ -51,9 +51,17 @@ export async function runCommand(argv: string[]): Promise<void> {
   const branchFlagIdx = argv.indexOf('--branch')
   const branchFlag = branchFlagIdx !== -1 ? argv[branchFlagIdx + 1] : undefined
 
+  const prdFlagIdx = argv.indexOf('--prd')
+  const prdFlag = prdFlagIdx !== -1 ? argv[prdFlagIdx + 1] : undefined
+
+  if (!prdFlag) {
+    console.error(c.error('Missing --prd <sprint-name>. Example: agentloop --prd mcp-server'))
+    process.exit(1)
+  }
+
   let prd
   try {
-    prd = await readPrd()
+    prd = await readPrd(prdFlag)
   } catch (err) {
     console.error(c.error(String(err instanceof Error ? err.message : err)))
     process.exit(1)

--- a/loop/src/lib/prd.ts
+++ b/loop/src/lib/prd.ts
@@ -17,30 +17,30 @@ export interface Prd {
   tasks: Task[]
 }
 
-const prdPath = () => join(process.cwd(), 'prd.json')
+const prdPath = (sprint: string) => join(process.cwd(), 'docs', 'prds', `${sprint}.json`)
 
-export async function readPrd(): Promise<Prd> {
-  const path = prdPath()
+export async function readPrd(sprint: string): Promise<Prd> {
+  const path = prdPath(sprint)
   const file = Bun.file(path)
 
   if (!(await file.exists())) {
-    throw new Error(`No prd.json found at ${path}. Run 'agentloop design' to create one.`)
+    throw new Error(`No PRD found at ${path}. Expected docs/prds/${sprint}.json`)
   }
 
   try {
     const prd = await file.json() as Prd
     if (!prd.sprint || !prd.tasks || !Array.isArray(prd.tasks)) {
-      throw new Error('prd.json looks malformed — expected sprint and tasks fields.')
+      throw new Error(`${path} looks malformed — expected sprint and tasks fields.`)
     }
     return prd
   } catch (err) {
     if (err instanceof SyntaxError) {
-      throw new Error(`prd.json is not valid JSON: ${err.message}`)
+      throw new Error(`${path} is not valid JSON: ${err.message}`)
     }
     throw err
   }
 }
 
 export async function writePrd(prd: Prd): Promise<void> {
-  await Bun.write(prdPath(), JSON.stringify(prd, null, 2) + '\n')
+  await Bun.write(prdPath(prd.sprint), JSON.stringify(prd, null, 2) + '\n')
 }


### PR DESCRIPTION
## Summary

Adds the `product-designer` agent that was missing from the previous PR.

Opus model. Writes `docs/plans/<feature>.md` and `prd.json` from brainstorm output. Key rules baked in:
- Tasks must not race on the same file — dependencies made explicit in descriptions
- Acceptance criteria must be script/test verifiable, not subjective
- Never use the `date` column — always derive from `start_time_utc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)